### PR TITLE
Fix health check status

### DIFF
--- a/server/controller/Health/health.controller.js
+++ b/server/controller/Health/health.controller.js
@@ -4,7 +4,7 @@ export default {
   self: (req, res) => {
     try {
       return res.status(200).json({
-        success: false,
+        success: true,
         message: 'Self-check',
         response: '',
       });


### PR DESCRIPTION
## Summary
- fix success flag for server /v1/self health check

## Testing
- `npm ci --silent` *(fails: MaxListenersExceededWarning)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c46cf70832981fcdc357159b5a2